### PR TITLE
Vulnerable Timer

### DIFF
--- a/Ghost.cs
+++ b/Ghost.cs
@@ -81,13 +81,6 @@ namespace PacMan {
             this.index = index;
         }
 
-        public void die() {
-            index = 0;
-            trajectory = 0;
-            isStuck = false;
-            delay = 0;
-        }
-
     }
 
 


### PR DESCRIPTION
Created a better solution for the vulnerable timer. Instead of having a third timer running concurrently to the other 2, I simply skip every other tick while the vulnderable state is active. This way the ghosts still slow down during the vulnerable phase and the code is more managable.